### PR TITLE
feat: round-trip cipherSuites in share links and VMess QR code

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/dto/VmessQRCode.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/dto/VmessQRCode.kt
@@ -16,6 +16,7 @@ data class VmessQRCode(
     var sni: String = "",
     var alpn: String = "",
     var fp: String = "",
+    var cs: String = "",
     var insecure: String = "",
     var vcn: String = "",
     var pcs: String = ""

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/fmt/FmtBase.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/fmt/FmtBase.kt
@@ -83,6 +83,7 @@ open class FmtBase {
         config.sni = queryParam["sni"]
         config.fingerPrint = queryParam["fp"]
         config.alpn = queryParam["alpn"]
+        config.cipherSuites = queryParam["cs"]
         config.echConfigList = queryParam["ech"]
         config.verifyPeerCertByName = queryParam["vcn"]
         config.pinnedCA256 = queryParam["pcs"]
@@ -104,6 +105,7 @@ open class FmtBase {
         dicQuery["security"] = config.security?.ifEmpty { "none" }.orEmpty()
         config.sni?.nullIfBlank()?.let { dicQuery["sni"] = it }
         config.alpn?.nullIfBlank()?.let { dicQuery["alpn"] = it }
+        config.cipherSuites?.nullIfBlank()?.let { dicQuery["cs"] = it }
         config.echConfigList?.nullIfBlank()?.let { dicQuery["ech"] = it }
         config.verifyPeerCertByName?.nullIfBlank()?.let { dicQuery["vcn"] = it }
         config.pinnedCA256?.nullIfBlank()?.let { dicQuery["pcs"] = it }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/fmt/VmessFmt.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/fmt/VmessFmt.kt
@@ -82,6 +82,7 @@ object VmessFmt : FmtBase() {
         config.sni = vmessQRCode.sni
         config.fingerPrint = vmessQRCode.fp
         config.alpn = vmessQRCode.alpn
+        config.cipherSuites = vmessQRCode.cs
         config.insecure = when (vmessQRCode.insecure) {
             "1" -> true
             "0" -> false
@@ -138,6 +139,7 @@ object VmessFmt : FmtBase() {
         vmessQRCode.sni = config.sni.orEmpty()
         vmessQRCode.fp = config.fingerPrint.orEmpty()
         vmessQRCode.alpn = config.alpn.orEmpty()
+        vmessQRCode.cs = config.cipherSuites.orEmpty()
         vmessQRCode.insecure = when (config.insecure) {
             true -> "1"
             false -> "0"


### PR DESCRIPTION
Follow-up to #1 and #2. This commit was pushed to the `fix/cipher-suites-followup` branch after #2 had already been merged, so it never landed in master — this PR picks it up.

## What changed

The fork already round-trips its custom TLS fields (`ech`, `vcn`, `pcs`, `pqv`) through share-link query parameters and the VMess QR-code JSON, but `cipherSuites` was missing, so sharing or exporting a profile silently dropped the setting.

- `FmtBase.getItemFormQuery` / `getQueryDic`: import and export a `cs` query parameter (emitted only when non-blank, matching the existing pattern).
- `VmessQRCode`: new `cs` field in the QR-code JSON DTO.
- `VmessFmt.parse` / `toUri`: map `cs` to `ProfileItem.cipherSuites` in both directions.

## Note for reviewers

The matching `cs` key is not yet supported by the v2rayN fork's `BaseFmt.cs`, so links carrying `cs=` interop with v2rayN only once the same key is added there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)